### PR TITLE
Changed secondary PM modifier to primary PM modifier

### DIFF
--- a/common/production_methods/4x_06_urban_center.txt
+++ b/common/production_methods/4x_06_urban_center.txt
@@ -289,7 +289,7 @@ pm_traditional_art = {
 		}
 	}
 	timed_modifiers = {
-		modifier_recently_adjusted_secondary_PM
+		modifier_recently_adjusted_primary_PM
 	}
 }
 
@@ -308,7 +308,7 @@ pm_realist_art = {
 		}
 	}
 	timed_modifiers = {
-		modifier_recently_adjusted_secondary_PM
+		modifier_recently_adjusted_primary_PM
 	}
 }
 
@@ -329,7 +329,7 @@ pm_photographic_art = {
 		}
 	}
 	timed_modifiers = {
-		modifier_recently_adjusted_secondary_PM
+		modifier_recently_adjusted_primary_PM
 	}
 }
 
@@ -353,7 +353,7 @@ pm_film_art = {
 
 	required_input_goods = electricity
 	timed_modifiers = {
-		modifier_recently_adjusted_secondary_PM
+		modifier_recently_adjusted_primary_PM
 	}
 }
 


### PR DESCRIPTION
I did notice in a game yesterday that switching the PMs in the art Academies applies the wrong modifier.
Here is the fix