### PR TITLE
Bavarian SGF cosmetic flavour if it controls all of South Germany

### DIFF
--- a/common/dynamic_country_names/mod_dynamic_country_names.txt
+++ b/common/dynamic_country_names/mod_dynamic_country_names.txt
@@ -1,0 +1,28 @@
+BAV = { # Bavaria
+	dynamic_country_name = {
+		name = dyn_c_bavarian_raterepublic
+		adjective = BAV_ADJ
+		
+		is_main_tag_only = no # good name for a communist revolution
+		priority = 0
+		
+		trigger = {
+			coa_def_communist_flag_trigger = yes
+		}
+	}
+	dynamic_country_name = {
+		name = dyn_c_bavarian_sgf
+		adjective = BAV_SGF_ADJ
+		priority = 999
+		trigger = {
+			exists = scope:actor
+			scope:actor ?= {
+				owns_entire_state_region = STATE_BAVARIA
+				owns_entire_state_region = STATE_FRANCONIA
+				owns_entire_state_region = STATE_WURTTEMBERG
+				owns_entire_state_region = STATE_BADEN
+			}
+		}
+
+	}
+}

--- a/common/flag_definitions/mod_bav_sgf.txt
+++ b/common/flag_definitions/mod_bav_sgf.txt
@@ -1,0 +1,61 @@
+BAV = { # Bavaria
+	flag_definition = {
+		coa = BAV
+		subject_canton = BAV
+		allow_overlord_canton = yes
+		priority = 1
+	}
+	flag_definition = {
+		coa = BAV_republic
+		subject_canton = BAV_republic
+		priority = 10
+		trigger = { 
+			coa_def_republic_flag_trigger = yes
+		}
+	}	
+	flag_definition = {
+		coa = BAV_absolute_monarchy
+		subject_canton = BAV_absolute_monarchy
+		priority = 20
+		trigger = { 
+			coa_def_absolute_monarchy_flag_trigger = yes
+		}
+	}	
+	flag_definition = {
+		coa = BAV_theocracy
+		subject_canton = BAV_theocracy
+		priority = 20
+		trigger = { 
+			coa_def_theocracy_flag_trigger = yes
+		}
+	}
+	flag_definition = {
+		coa = BAV_communist
+		priority = 1500
+		trigger = { 
+			coa_def_communist_flag_trigger = yes
+		}
+	}	
+	flag_definition = {
+		coa = BAV_subject_PRU
+		priority = 50
+		trigger = { 
+			coa_def_prussian_ensign_trigger = yes
+		}
+	}
+	flag_definition = {
+		coa = SGF
+		subject_canton = SGF
+		allow_overlord_canton = yes
+		priority = 999
+		trigger = {
+			exists = scope:actor
+			scope:actor ?= {
+				owns_entire_state_region = STATE_BAVARIA
+				owns_entire_state_region = STATE_FRANCONIA
+				owns_entire_state_region = STATE_WURTTEMBERG
+				owns_entire_state_region = STATE_BADEN
+			}
+		}
+	}
+}

--- a/localization/english/4x_games_mod/mod_bavarian_sgf_l_english.yml
+++ b/localization/english/4x_games_mod/mod_bavarian_sgf_l_english.yml
@@ -1,0 +1,3 @@
+﻿l_english:
+ BAV_SGF_ADJ:0 "South German"
+ dyn_c_bavarian_sgf: "South German Federation"


### PR DESCRIPTION
Rename Bavaria to South German Federation and give the SGF flag if it controls Baden, Württemberg, Franconia and Bavaria. Tag stays the same, so this is only cosmetic.